### PR TITLE
Provide a disconnect only option that is safe to use with transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or install it yourself as:
     $ gem install mysql2-aurora
 
 ## Usage
-This gem extends Mysql2::Client. You can use `aurora_max_retry` option.
+This gem extends Mysql2::Client. You can use `aurora_max_retry` and `aurora_disconnect_on_readonly` options.
 
 ```ruby
 Mysql2::Client.new(
@@ -30,7 +30,8 @@ Mysql2::Client.new(
   username:         'root',
   password:         'change_me',
   reconnect:        true,
-  aurora_max_retry: 5
+  aurora_max_retry: 5,
+  aurora_disconnect_on_readonly: true
 )
 ```
 
@@ -44,7 +45,38 @@ development:
   password:         change_me
   reconnect:        true
   aurora_max_retry: 5
+  aurora_disconnect_on_readonly: true
+
 ```
+
+There are essentially two methods for handling and RDS Aurora failover. When there is an Aurora RDS failover event the primary writable server can change it's role to become a read_only replica. This can happen without active database connections droppping.
+This leaves the connection in a state where writes will fail, but the application belives it's connected to a writeable server. Writes will now perpetually fail until the database connection is closed and re-established connecting back to the new primary.
+
+To provide automatic recovery from this method you can use either a graceful retry, or an immediate disconnection option.
+
+### Retry
+
+Setting aurora_max_retry, mysql2 will not disconnect and automatically attempt re-connection to the database when a read_only error message is encountered.
+This has the benefit that to the application the error is transparent and the query will be re-run against the new primary when the connection succeeds.
+
+It is however not safe to use with transactions
+
+Consider:
+
+* Transaction is started on the primary server A
+* Failover event occurs, A is now readonly
+* Application issues a write statement, read_only exception is thrown
+* mysql2-aurora gem handles this by reconnecting transparently to the new primary B
+* Aplication continues issuing writes however on a new connection in auto-commit mode, no new transaction was started
+
+The application remains un-aware it is now operating outside of a transaction, this can leave data in an inconcistent state, and issuing a ROLLBACK, or COMMIT will not have the expected outcome.
+
+### Immediate disconnect
+
+Setting aurora_disconnect_on_readonly to true, will cause mysql2 to close the connection to the database on read_only exception. The original exception will be thrown up the stack to the application.
+With the database connection disconnected, the next statement will hit the disconnected error and the application can handle this as it would normally when been disconnected from the database.
+
+This is safe with transactions.
 
 ## Contributing
 

--- a/lib/mysql2/aurora.rb
+++ b/lib/mysql2/aurora.rb
@@ -13,9 +13,11 @@ module Mysql2
       # @note [Override] with reconnect options
       # @param [Hash] opts Options
       # @option opts [Integer] aurora_max_retry Max retry count, when failover. (Default: 5)
+      # @option opts [Bool] aurora_disconnect_on_readonly, when readonly exception hit terminate the connection (Default: false)
       def initialize(opts)
-        @opts      = Mysql2::Util.key_hash_as_symbols(opts)
+        @opts = Mysql2::Util.key_hash_as_symbols(opts)
         @max_retry = @opts.delete(:aurora_max_retry) || 5
+        @disconnect_only = @opts.delete(:aurora_disconnect_on_readonly) || false
         reconnect!
       end
 
@@ -29,17 +31,21 @@ module Mysql2
         rescue Mysql2::Error => e
           try_count += 1
 
-          if e.message&.include?('--read-only') && try_count <= @max_retry
-            retry_interval_seconds = [1.5 * (try_count - 1), 10].min
+          if e.message&.include?('--read-only')
+            if @disconnect_only
+              warn '[mysql2-aurora] Database is readonly, Aurora failover event likely occured, closing database connection'
+              disconnect!
+              raise e
+            elsif try_count <= @max_retry
+              retry_interval_seconds = [1.5 * (try_count - 1), 10].min
 
-            warn "[mysql2-aurora] Database is readonly. Retry after #{retry_interval_seconds}seconds"
-            sleep retry_interval_seconds
-            reconnect!
-
-            retry
-          else
-            raise e
+              warn "[mysql2-aurora] Database is readonly. Retry after #{retry_interval_seconds}seconds"
+              sleep retry_interval_seconds
+              reconnect!
+              retry
+            end
           end
+          raise e
         end
       end
 
@@ -48,14 +54,17 @@ module Mysql2
       def reconnect!
         query_options = (@client&.query_options&.dup || {})
 
-        begin
-          @client&.close
-        rescue StandardError
-          nil
-        end
+        disconnect!
 
         @client = Mysql2::Aurora::ORIGINAL_CLIENT_CLASS.new(@opts)
         @client.query_options.merge!(query_options)
+      end
+
+      # Close connection to database server
+      def disconnect!
+        @client&.close
+      rescue StandardError
+        nil
       end
 
       # Delegate method call to client.

--- a/spec/mysql2/aurora_spec.rb
+++ b/spec/mysql2/aurora_spec.rb
@@ -49,6 +49,34 @@ RSpec.describe Mysql2::Aurora::Client do
   end
 
   describe '#query' do
+    context 'When aurora_disconnect_on_readonly is true' do
+      let :client do
+        Mysql2::Client.new(
+          host:                          ENV['TEST_DB_HOST'],
+          username:                      ENV['TEST_DB_USER'],
+          password:                      ENV['TEST_DB_PASS'],
+          aurora_max_retry:              10,
+          aurora_disconnect_on_readonly: true
+        )
+      end
+
+      before :each do
+        allow(client).to receive(:warn)
+        allow(client.client).to receive(:query).and_raise(Mysql2::Error, 'ERROR 1290 (HY000): The MySQL server is running with the --read-only option so it cannot execute this statement')
+      end
+
+      subject do
+        client.query('SELECT CURRENT_USER() AS user')
+      end
+
+      describe '#query' do
+        it 'disconnects immediately' do
+          expect(client).to receive(:disconnect!)
+          expect { subject }.to raise_error(Mysql2::Error)
+        end
+      end
+    end
+
     subject do
       client.query('SELECT CURRENT_USER() AS user')
     end


### PR DESCRIPTION
Transparent retry as this gem currently performs it is not safe when using transactions can introduce data
integrity issues.

This commit adds an option to simply disconnect on
read_only errors. Leaving the application to deal with the failover
event as it would a normal disconnection.

This allows transactions to be
restarted as needed and will not leave the application in a dangerous
state where it's operating in autocommit mode, but belives it's inside a
transaction.