### PR TITLE
Ensure connection flags are supported

### DIFF
--- a/lib/mysql2/aurora.rb
+++ b/lib/mysql2/aurora.rb
@@ -88,6 +88,12 @@ module Mysql2
       def self.const_missing(name)
         Mysql2::Aurora::ORIGINAL_CLIENT_CLASS.const_get(name)
       end
+
+      # Delegate const definition to class.
+      # @param [Symbol] name Const name
+      def self.const_defined?(name)
+        Mysql2::Aurora::ORIGINAL_CLIENT_CLASS.const_defined?(name)
+      end
     end
 
     # Swap Mysql2::Client

--- a/spec/mysql2/aurora_spec.rb
+++ b/spec/mysql2/aurora_spec.rb
@@ -186,6 +186,27 @@ RSpec.describe Mysql2::Aurora::Client do
     end
   end
 
+  describe 'connection flags' do
+    let :multi_client do
+      Mysql2::Client.new(
+        host:                          ENV['TEST_DB_HOST'],
+        username:                      ENV['TEST_DB_USER'],
+        password:                      ENV['TEST_DB_PASS'],
+        aurora_max_retry:              10,
+        aurora_disconnect_on_readonly: aurora_disconnect_on_readonly,
+        flags: ["MULTI_STATEMENTS"]
+      )
+    end
+
+    subject do
+      multi_client.query('SELECT CURRENT_USER() AS user; SELECT CURRENT_USER() AS user;')
+    end
+
+    it 'supports multi statements after reconnect' do
+      expect { subject }.to_not raise_error
+    end
+  end
+
   describe '#method_missing' do
     subject do
       client.ping


### PR DESCRIPTION
Discovered that connection flags were not being passed to the client with Rails.

The flag parsing in `Mysql2::Client` first checks if the constant is defined before setting the flag, and this was failing as the original client had been swapped out, leading to the odd situation where you could see the value of the constant, but it was saying it wasn't defined.

```
irb> Mysql2::Client.const_get("MULTI_STATEMENTS")
=> 65536
irb> Mysql2::Client.const_defined?("MULTI_STATEMENTS")
=> true
```

Solution is to also  delegate `const_defined?` to the origin client.